### PR TITLE
Fix Vercel routing — drop /api rewrites, gate static mount behind VERCEL env

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,9 +9,9 @@ This deploys the web app (landing page + 25-tool runner) to Vercel as Python ser
 | `/` | `public/index.html` | Landing page with tool catalog |
 | `/app` | `public/app.html` | Tool runner UI |
 | `/styles.css` `/app.js` | `public/` | Static assets |
-| `/api/health` | `api/index.py` → `plugin/server/app.py` | Health check |
-| `/api/tools` | `api/index.py` | Tool registry (categories + params) |
-| `/api/tools/{key}/run` | `api/index.py` | Execute a tool with JSON params |
+| `/api/health` | `app.py` → `plugin/server/app.py` | Health check |
+| `/api/tools` | `app.py` | Tool registry (categories + params) |
+| `/api/tools/{key}/run` | `app.py` | Execute a tool with JSON params |
 
 Everything else (TUI, MCP server, Excel add-in, Claude Code skills) is **not** part of the Vercel deploy. They remain installable locally for power users.
 
@@ -36,7 +36,7 @@ vercel --prod       # deploy to production
 
 Vercel auto-detects:
 - `requirements.txt` → installs FastAPI for the Python runtime
-- `api/index.py` → mounts as a serverless function
+- `app.py` → mounts as a serverless function
 - `public/` → serves as static files
 - `vercel.json` → routing + headers
 
@@ -44,11 +44,11 @@ Vercel auto-detects:
 
 ```bash
 source .venv/bin/activate     # or create a venv with fastapi + uvicorn
-uvicorn api.index:app --reload --port 8765
+uvicorn app:app --reload --port 8765
 # visit http://127.0.0.1:8765
 ```
 
-`api/index.py` also mounts `public/` as static for local dev, so the full app works under uvicorn without `vercel dev`.
+`app.py` also mounts `public/` as static for local dev, so the full app works under uvicorn without `vercel dev`.
 
 ## Environment variables
 
@@ -56,8 +56,8 @@ Set in the Vercel dashboard under **Settings → Environment Variables**:
 
 | Var | Default | Notes |
 |-----|---------|-------|
-| `ALPHA_STACK_STATE_DIR` | `/tmp/alpha-stack/sessions` | Set by `api/index.py`; safe to leave default |
-| `ALPHA_STACK_WIKI_DIR` | `/tmp/alpha-stack/wiki` | Set by `api/index.py`; safe to leave default |
+| `ALPHA_STACK_STATE_DIR` | `/tmp/alpha-stack/sessions` | Set by `app.py`; safe to leave default |
+| `ALPHA_STACK_WIKI_DIR` | `/tmp/alpha-stack/wiki` | Set by `app.py`; safe to leave default |
 
 Neither is required, and neither persists. If you want a real persistence layer for sessions/wiki, swap in Vercel KV, Postgres, or Blob Storage — the read/write surface is small (see [tools/state.py](tools/state.py) and [tools/wiki.py](tools/wiki.py)).
 

--- a/api/index.py
+++ b/api/index.py
@@ -65,23 +65,26 @@ if _BASE_APP is not None:
     app.mount("/api", _BASE_APP)
 
 
-# ── Local-dev only routes (Vercel handles /, /app, /chat via static + rewrites) ──
+# ── Local-dev only routes (Vercel handles /, /app, /chat via static + cleanUrls) ──
+# On Vercel, VERCEL env var is always set. Don't register the static mount there —
+# Vercel serves public/ directly from its edge, and an extra mount would compete
+# for the same paths.
 _PUBLIC_DIR = os.path.join(_ROOT, "public")
+_IS_VERCEL = os.environ.get("VERCEL") == "1"
 
+if not _IS_VERCEL:
 
-@app.get("/app")
-async def app_page():
-    p = os.path.join(_PUBLIC_DIR, "app.html")
-    return FileResponse(p) if os.path.isfile(p) else JSONResponse({"error": "app.html missing"}, status_code=404)
+    @app.get("/app")
+    async def app_page():
+        p = os.path.join(_PUBLIC_DIR, "app.html")
+        return FileResponse(p) if os.path.isfile(p) else JSONResponse({"error": "app.html missing"}, status_code=404)
 
+    @app.get("/chat")
+    async def chat_page():
+        p = os.path.join(_PUBLIC_DIR, "chat.html")
+        return FileResponse(p) if os.path.isfile(p) else JSONResponse({"error": "chat.html missing"}, status_code=404)
 
-@app.get("/chat")
-async def chat_page():
-    p = os.path.join(_PUBLIC_DIR, "chat.html")
-    return FileResponse(p) if os.path.isfile(p) else JSONResponse({"error": "chat.html missing"}, status_code=404)
+    if os.path.isdir(_PUBLIC_DIR):
+        from fastapi.staticfiles import StaticFiles  # noqa: E402
 
-
-if os.path.isdir(_PUBLIC_DIR):
-    from fastapi.staticfiles import StaticFiles  # noqa: E402
-
-    app.mount("/", StaticFiles(directory=_PUBLIC_DIR, html=True), name="public")
+        app.mount("/", StaticFiles(directory=_PUBLIC_DIR, html=True), name="public")

--- a/app.py
+++ b/app.py
@@ -1,22 +1,23 @@
-"""Vercel Python serverless entry point.
+"""Vercel Python entrypoint — lives at the project root so Vercel's framework
+preset for FastAPI auto-detects it. Putting this in `api/` instead would flip
+Vercel into legacy "serverless functions directory" mode where each .py file
+in api/ is treated as a separate function, and the framework preset for
+routing to the whole FastAPI app is disabled.
 
-Wraps the existing FastAPI app so it's reachable at /api/*.
-The base app's routes (e.g. /health, /tools) become /api/health, /api/tools.
+The actual route logic lives in plugin/server/app.py and plugin/server/chat.py.
+This file is just the entrypoint Vercel loads.
 
-Heavy imports are wrapped so that if they fail (missing sibling dirs,
-missing deps), /api/__diag still responds with what went wrong.
-Route order matters — /api/__diag is registered BEFORE the /api mount
-so it takes precedence over the mounted sub-app.
+Heavy imports are wrapped so that if they fail, /api/__diag still responds
+with what went wrong. Route order matters — /api/__diag is registered BEFORE
+the /api mount so it takes precedence over the mounted sub-app.
 """
 
 import os
 import sys
 import traceback
 
-# Make project root importable. On Vercel, __file__ resolves under /var/task/api/,
-# so _ROOT = /var/task. tools/, plugin/, tui/ get bundled via vercel.json
-# `includeFiles`.
-_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# app.py lives at the project root, so _ROOT is just its own directory.
+_ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _ROOT)
 sys.path.insert(0, os.path.join(_ROOT, "tools"))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ tui = ["textual>=1.0.0", "yfinance>=0.2.0"]
 excel = ["fastapi>=0.115.0", "uvicorn[standard]>=0.20.0"]
 
 [tool.vercel]
-entrypoint = "api.index:app"
+entrypoint = "app:app"
 
 [tool.uv]
 package = false

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/index.py" },
-    { "source": "/app", "destination": "/app.html" },
-    { "source": "/chat", "destination": "/chat.html" }
-  ],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## What was wrong

Even after merging #56, `/api/*` requests returned errors. Per Vercel's FastAPI docs:

1. **The `/api/(.*)` rewrite was harmful.** Vercel's framework preset already routes every request (including `/api/*`) to the FastAPI app's entrypoint — no rewrite needed. My rewrite was forcing Vercel to try to serve `/api/index.py` as a *static file* instead of invoking the function.

2. **The `app.mount("/", StaticFiles(...))` competed with Vercel's CDN.** Vercel docs explicitly warn: `"app.mount('/public', ...) is not needed and should not be used."` Same applies to mounting `/`.

## Fix

- **vercel.json**: drop all rewrites. Keep `cleanUrls: true` (handles `/app` → `/app.html` and `/chat` → `/chat.html`) and the CORS headers.
- **api/index.py**: gate the static mount and local `/app`/`/chat` routes behind `if not _IS_VERCEL` (Vercel sets `VERCEL=1`). Locally these still work for `uvicorn` dev. On Vercel they're skipped so Vercel's CDN can serve `public/` cleanly.

## How routing now works on Vercel

| Request | Served by |
|---|---|
| `/`, `/styles.css`, `/favicon.svg` | Vercel CDN from `public/` |
| `/app`, `/chat` | Vercel CDN with cleanUrls → `public/app.html`, `public/chat.html` |
| `/api/health`, `/api/tools`, `/api/chat`, `/api/tools/*/run`, `/api/tools/*/sensitivity`, `/api/templates/web`, `/api/__diag` | FastAPI app at `api/index.py` (mount `/api` → base_app routes) |

## Test plan
- [ ] `vercel --prod` build succeeds
- [ ] Production landing page populates tool cards (no "API unreachable")
- [ ] `/api/__diag` returns JSON with `ok: true` and shows all sibling dirs present
- [ ] LBO template card → tool runner pre-filled
- [ ] Chat works with a real `sk-ant-` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)