### PR TITLE
Force fastapi framework preset — production was stuck on Other (static-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,15 @@ excel = ["fastapi>=0.115.0", "uvicorn[standard]>=0.20.0"]
 [tool.vercel]
 entrypoint = "app:app"
 
-[tool.uv]
-package = false
+# Without [build-system], Vercel may skip the Python build step for this
+# project (it gets detected as static-only). Keep hatchling configured but
+# minimal — it's enough to trigger Python detection.
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.ruff]
 target-version = "py310"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "fastapi",
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Smoking gun

Curled production directly:
```
$ curl -I https://alpha-stack-virid.vercel.app/api/health
HTTP/2 200
content-type: text/html; charset=utf-8
etag: \"d094573f40470db352bda197d6b22a75\"
x-vercel-cache: HIT
```

Same etag, content-type html, cache-hit — Vercel is serving `public/index.html` for **every** /api/* path. The Python function never ran. The framework preset never activated.

## Why

The project was originally deployed when the entrypoint was in `api/`, which Vercel interprets as legacy "serverless functions directory" mode. It seems Vercel locked the project's Framework Preset to "Other" (static-only) at that point, and subsequent commits kept inheriting that setting even after we moved to `app.py` at root.

## Fix

Two changes:

1. **vercel.json `"framework": "fastapi"`** — per [the vercel.json reference](https://vercel.com/docs/project-configuration/vercel-json#framework), this property overrides the dashboard's Framework Preset. Forces Vercel to treat the deploy as FastAPI: bundle Python deps, deploy the entrypoint as a function, route every request to it.

2. **pyproject.toml: restore `[build-system]` with hatchling** — without it Vercel may skip Python detection entirely. The previous `[tool.uv] package = false` was the wrong direction.

## Test plan

After merge + auto-deploy, expect:
- [ ] `curl -I https://alpha-stack-virid.vercel.app/api/health` → returns JSON, content-type `application/json`, NOT `text/html`
- [ ] `/api/__diag` returns JSON with `ok: true`
- [ ] Tool grid populates on the homepage
- [ ] Chat works with an `sk-ant-` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)