### PR TITLE
Force Python function build via explicit runtime + rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "fastapi",
+  "framework": null,
+  "buildCommand": null,
+  "outputDirectory": null,
+  "installCommand": null,
+  "functions": {
+    "app.py": {
+      "runtime": "@vercel/python@6.40.0"
+    }
+  },
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/app.py" }
+  ],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
Last fix attempt before reset. Forces app.py to be deployed as a @vercel/python serverless function and adds explicit /api/* → /app.py rewrite. If this still fails, the Vercel project state is corrupted and needs a manual reset.